### PR TITLE
Add missing root documentation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# vim
+*.swp
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+coverage.txt
+report.json
+
+*vendor/
+
+#Goland
+.idea/
+
+# Images
+*.png
+
+# VSCode
+*.code-workspace
+.vscode/*
+
+# Environment files
+.env
+
+# Go workspace files
+go.work*
+
+# PEM files
+*.pem

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -34,3 +34,15 @@ License: Apache-2.0
 Files: .whitesource
 Copyright: SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 License: Apache-2.0
+
+Files: AUTHORS
+Copyright: SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+License: Apache-2.0
+
+Files: CHANGELOG.md
+Copyright: SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+License: Apache-2.0
+
+Files: CONTRIBUTING.md
+Copyright: SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+License: Apache-2.0

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Weston Schmidt: Original Author

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project are documented in [GitHub Releases](https://github.com/xmidt-org/argus-dynamodb/releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+Contribution Guidelines
+=======================
+
+We love to see contributions to the project and have tried to make it easy to 
+do so. If you would like to contribute code to this project you can do so 
+through GitHub by [forking the repository and sending a pull request](http://gun.io/blog/how-to-github-fork-branch-and-pull-request/).
+
+Before Comcast merges your code into the project you must sign the 
+[Comcast Contributor License Agreement (CLA)](https://gist.github.com/ComcastOSS/a7b8933dd8e368535378cda25c92d19a).
+
+If you haven't previously signed a Comcast CLA, you'll automatically be asked 
+to when you open a pull request. Alternatively, we can e-mail you a PDF that 
+you can sign and scan back to us. Please send us an e-mail or create a new 
+GitHub issue to request a PDF version of the CLA.
+
+If you have a trivial fix or improvement, please create a pull request and 
+request a review from a [maintainer](MAINTAINERS.md) of this repository.
+
+If you plan to do something more involved, that involves a new feature or 
+changing functionality, please first create an [issue](#issues) so a discussion of 
+your idea can happen, avoiding unnecessary work and clarifying implementation.
+
+A relevant coding style guideline is the [Go Code Review Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments).
+
+Documentation
+-------------
+
+If you contribute anything that changes the behavior of the application, 
+document it in the follow places as applicable:
+* the code itself, through clear comments and unit tests
+* [README](README.md)
+
+This includes new features, additional variants of behavior, and breaking 
+changes.
+
+Testing
+-------
+
+Tests are written using golang's standard testing tools, and are run prior to 
+the PR being accepted.
+
+Issues
+------
+
+For creating an issue:
+* **Bugs:** please be as thorough as possible, with steps to recreate the issue 
+  and any other relevant information.
+* **Feature Requests:** please include functionality and use cases.  If this is 
+  an extension of a current feature, please include whether or not this would 
+  be a breaking change or how to extend the feature with backwards 
+  compatibility.
+* **Security Vulnerability:** please report it at 
+  https://my.xfinity.com/vulnerabilityreport and contact the [maintainers](MAINTAINERS.md).
+
+If you wish to work on an issue, please assign it to yourself.  If you have any
+questions regarding implementation, feel free to ask clarifying questions on 
+the issue itself.
+
+Pull Requests
+-------------
+
+* should be narrowly focused with no more than 3 or 4 logical commits
+* when possible, address no more than one issue
+* should be reviewable in the GitHub code review tool
+* should be linked to any issues it relates to (i.e. issue number after (#) in commit messages or pull request message)
+* should conform to idiomatic golang code formatting

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,19 @@
+SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+SPDX-License-Identifier: Apache-2.0
+
+argus-dynamodb
+Copyright 2023 Comcast Cable Communications Management, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This product includes software developed at Comcast (http://www.comcast.com/).


### PR DESCRIPTION
## Summary

Adds all missing root documentation files required by the North Star checklist:
- NOTICE file with Apache 2.0 copyright attribution
- AUTHORS file listing original author (Weston Schmidt)
- CONTRIBUTING.md with CLA requirements, PR guidelines, and security vulnerability reporting
- .gitignore with standard Go patterns (binaries, test output, .env, .vscode, *.pem, go.work*)
- CHANGELOG.md directing readers to GitHub Releases

## Related Issue

Resolves #210

## Changes

- ✅ Added NOTICE with proper copyright and Apache 2.0 license info
- ✅ Added AUTHORS with original author
- ✅ Added CONTRIBUTING.md following XMiDT standard format
- ✅ Added .gitignore with Go-specific ignore patterns
- ✅ Added CHANGELOG.md referencing GitHub Releases

All files follow the format used in reference repos (wrp-go, wrpssp).