### PR TITLE
Add auto-releaser workflow and fix permissions

### DIFF
--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Auto Releaser'
+
+on:
+  schedule:
+    # Run daily at 12:00 UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  release:
+    uses: xmidt-org/.github/.github/workflows/release.yml@v1
+    secrets: inherit

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,6 +11,8 @@ on:
     types:
       - opened
 
+permissions: {}
+
 jobs:
   package:
     uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1


### PR DESCRIPTION
## Summary

- Add `.github/workflows/auto-releaser.yml` using the shared workflow
- Configure auto-releaser to run daily at 12:00 UTC
- Add manual dispatch trigger to auto-releaser
- Update `proj-xmidt-team.yml` to include `permissions: {}`

Fixes #214