### PR TITLE
Add permissions field to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@766cd1914571123cc26ab6e0f1782c784dc4f11f # v4.4.28


### PR DESCRIPTION
## Summary

This PR adds the `permissions: {}` field to the CI workflow, ensuring it explicitly inherits no permissions while secrets are passed via `secrets: inherit`.

### Changes

- ✅ Added `permissions: {}` to `.github/workflows/ci.yml`
- Aligns with security best practices for reusable workflows
- Consistent with other workflows (auto-releaser.yml, proj-xmidt-team.yml)

### Context

Reusable workflows should explicitly set `permissions: {}` to ensure they inherit no permissions by default. Secrets are still properly passed via `secrets: inherit`.