### PR TITLE
Fix CI workflow permissions to match xmidt-org standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  pull-requests: read
+  contents:      write
+  packages:      write
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary

This PR corrects the permissions in the CI workflow to match the standard used across xmidt-org repositories (e.g., wrpssp, wrp-go).

### Changes

- ✅ Changed `permissions: {}` to proper permissions:
  - `pull-requests: read`
  - `contents: write`
  - `packages: write`

### Context

The previous PR (#220) incorrectly set `permissions: {}`, but the xmidt-org standard for CI workflows is to explicitly grant:
- `pull-requests: read` - for PR operations
- `contents: write` - for creating releases and tags
- `packages: write` - for publishing packages

This matches the permissions used in [wrpssp](https://github.com/xmidt-org/wrpssp/blob/main/.github/workflows/ci.yml) and [wrp-go](https://github.com/xmidt-org/wrp-go/blob/main/.github/workflows/ci.yml).