### PR TITLE
Fix lint issues and add golangci-lint configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
-
+---
 version: 2
 
 linters:
@@ -30,7 +30,7 @@ issues:
       linters:
         - dupl
         - funlen
-    # Exclude SA1019 deprecation warnings for AWS SDK v1  
+    # Exclude SA1019 deprecation warnings for AWS SDK v1
     - text: "SA1019"
       linters:
         - staticcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+version: 2
+
+linters:
+  enable:
+    - bodyclose
+    - dupl
+    - errorlint
+    - funlen
+    - goconst
+    - gosec
+    - misspell
+    - prealloc
+    - unconvert
+
+linters-settings:
+  funlen:
+    lines: 80  # Allow slightly longer functions
+  staticcheck:
+    checks:
+      - all
+      - -SA1019  # Ignore deprecation warnings (AWS SDK v1 migration is a larger effort)
+
+issues:
+  exclude-rules:
+    # Exclude dupl and funlen checks for test files
+    - path: _test\.go
+      linters:
+        - dupl
+        - funlen
+    # Exclude SA1019 deprecation warnings for AWS SDK v1  
+    - text: "SA1019"
+      linters:
+        - staticcheck

--- a/argus.go
+++ b/argus.go
@@ -6,8 +6,8 @@ package argusdynamodb
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/aws"              //nolint:staticcheck // AWS SDK v1 migration is a larger effort
+	"github.com/aws/aws-sdk-go/service/dynamodb" //nolint:staticcheck // AWS SDK v1 migration is a larger effort
 	"github.com/xmidt-org/argus-dynamodb/dynamo"
 )
 

--- a/dynamo/dynamo.go
+++ b/dynamo/dynamo.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/aws"              //nolint:staticcheck // AWS SDK v1 migration is a larger effort
+	"github.com/aws/aws-sdk-go/aws/credentials"  //nolint:staticcheck // AWS SDK v1 migration is a larger effort
+	"github.com/aws/aws-sdk-go/aws/session"      //nolint:staticcheck // AWS SDK v1 migration is a larger effort
+	"github.com/aws/aws-sdk-go/service/dynamodb" //nolint:staticcheck // AWS SDK v1 migration is a larger effort
 )
 
 type Dynamo struct {
@@ -50,13 +50,14 @@ func (o optionFunc) apply(a *Dynamo) error {
 func New(opts ...Option) (*Dynamo, error) {
 	var d Dynamo
 
-	defaults := []Option{
+	defaults := make([]Option, 0, 5+len(opts))
+	defaults = append(defaults,
 		Stdout(os.Stdout),
-		MaxWaitForDynamo(10 * time.Second),
-		MaxDynamoResponseWait(20 * time.Microsecond),
-		MaxDynamoActionWait(5 * time.Second),
-		GeneralDelay(10 * time.Millisecond),
-	}
+		MaxWaitForDynamo(10*time.Second),
+		MaxDynamoResponseWait(20*time.Microsecond),
+		MaxDynamoActionWait(5*time.Second),
+		GeneralDelay(10*time.Millisecond),
+	)
 
 	opts = append(defaults, opts...)
 

--- a/dynamo/dynamo_test.go
+++ b/dynamo/dynamo_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/aws"              //nolint:staticcheck // AWS SDK v1 migration is a larger effort
+	"github.com/aws/aws-sdk-go/service/dynamodb" //nolint:staticcheck // AWS SDK v1 migration is a larger effort
 	"github.com/stretchr/testify/assert"
 	"github.com/xmidt-org/argus-dynamodb/dynamo"
 	"github.com/xmidt-org/idock"
@@ -111,6 +111,7 @@ func TestEnd2End(t *testing.T) {
 	}
 }
 
+//nolint:funlen // Test table is long but clear
 func TestWarnings(t *testing.T) {
 	tests := []struct {
 		description string


### PR DESCRIPTION
## Summary

This PR fixes all golangci-lint issues and adds the `.golangci.yaml` configuration file with required linters enabled.

### Changes

#### Configuration
- ✅ Added `.golangci.yaml` with version 2 configuration
- ✅ Enabled required linters: bodyclose, dupl, errorlint, funlen, goconst, gosec, misspell, prealloc, unconvert
- ✅ Configured funlen to allow up to 80 lines
- ✅ Excluded dupl and funlen checks for test files

#### Code Fixes
- ✅ Fixed prealloc issue in `dynamo/dynamo.go` by preallocating slice with proper capacity
- ✅ Added `//nolint:staticcheck` directives to AWS SDK v1 imports (migration to v2 is a larger effort)
- ✅ Added `//nolint:funlen` directive to `TestWarnings` (long test table is clear and readable)

### Verification

- ✅ `golangci-lint run` passes with 0 issues
- ✅ All tests pass (`go test ./...`)

### Context

The main lint issues were:
1. **SA1019 deprecation warnings**: AWS SDK v1 is deprecated, but migrating to v2 is a substantial effort requiring architectural changes - suppressed with nolint directives
2. **prealloc**: Fixed by preallocating slice capacity in `New()` function
3. **funlen**: Test function excluded as it's a clear, readable test table

This partially addresses issue #215 by adding the `.golangci.yaml` configuration file.