### PR TITLE
Migrate workflows to xmidt-org/shared-go and fix permissions

### DIFF
--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -9,9 +9,10 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   release:
-    uses: xmidt-org/.github/.github/workflows/release.yml@v1
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/dependabot-approver.yml
+++ b/.github/workflows/dependabot-approver.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,9 +11,12 @@ on:
     types:
       - opened
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

- Migrate three workflows from `xmidt-org/.github` to `xmidt-org/shared-go`
- Pin all workflow references to commit SHAs instead of tags
- Add missing permissions to workflows

## Changes

### auto-releaser.yml
- Changed from `xmidt-org/.github/.github/workflows/release.yml@v1`
- To `xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471` (SHA for v4.9.41)
- Added `permissions.contents: write` (was empty)

### dependabot-approver.yml
- Changed from `xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main`
- To `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471` (SHA for v4.9.41)
- SHA pinning replaces tag reference

### proj-xmidt-team.yml
- Changed from `xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1`
- To `xmidt-org/shared-go/.github/workflows/proj.yml@aff0471` (SHA for v4.9.41)
- Added required permissions: `contents: read`, `issues: write`, `pull-requests: write` (was empty)

## Issues

Fixes #229 - Update workflows to use xmidt-org/shared-go
Fixes #227 - Fix workflow permissions
Fixes #226 - Fix workflow action pinning to use commit SHAs