### PR TITLE
Fix golangci-lint v2 config format

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-version: 2
+version: "2"
 
 linters:
   enable:
@@ -14,23 +14,19 @@ linters:
     - misspell
     - prealloc
     - unconvert
-
-linters-settings:
-  funlen:
-    lines: 80  # Allow slightly longer functions
-  staticcheck:
-    checks:
-      - all
-      - -SA1019  # Ignore deprecation warnings (AWS SDK v1 migration is a larger effort)
-
-issues:
-  exclude-rules:
-    # Exclude dupl and funlen checks for test files
-    - path: _test\.go
-      linters:
-        - dupl
-        - funlen
-    # Exclude SA1019 deprecation warnings for AWS SDK v1
-    - text: "SA1019"
-      linters:
-        - staticcheck
+  settings:
+    funlen:
+      lines: 80
+    staticcheck:
+      checks:
+        - all
+        - -SA1019
+  exclusions:
+    rules:
+      - linters:
+          - dupl
+          - funlen
+        path: _test.go
+      - linters:
+          - staticcheck
+        text: "SA1019"


### PR DESCRIPTION
## Summary

Fix `.golangci.yaml` to use correct v2 format syntax, resolving CI failures.

## Problem

The CI was failing with errors:
```
jsonschema: "version" does not validate with "/properties/version/type": got number, want string
jsonschema: "issues" does not validate with "/properties/issues/additionalProperties": additional properties 'exclude-rules' not allowed
jsonschema: "" does not validate with "/additionalProperties": additional properties 'linters-settings' not allowed
```

## Changes

- Change `version: 2` to `version: "2"` (string instead of number)
- Move `linters-settings` → `linters.settings`
- Move `issues.exclude-rules` → `linters.exclusions.rules`

## Testing

Verified with `golangci-lint config verify` - no errors.

Reference: [wrpssp .golangci.yaml](https://github.com/xmidt-org/wrpssp/blob/main/.golangci.yaml)