### PR TITLE
Add package comments to satisfy staticcheck

### DIFF
--- a/argus.go
+++ b/argus.go
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// Package argusdynamodb provides integration testing support for Argus by creating
+// and managing DynamoDB tables with the Argus schema.
 package argusdynamodb
 
 import (

--- a/dynamo/dynamo.go
+++ b/dynamo/dynamo.go
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 // SPDX-License-Identifier: Apache-2.0
 
+// Package dynamo provides a simplified interface for creating and managing DynamoDB
+// tables for integration testing, with support for table lifecycle management.
 package dynamo
 
 import (


### PR DESCRIPTION
## Summary

Add package-level comments to resolve staticcheck ST1000 linter warnings.

## Changes

- Add package comment to `argusdynamodb` package in `argus.go`
- Add package comment to `dynamo` package in `dynamo/dynamo.go`

## Linter Output Before

```
argus.go:4:1: ST1000: at least one file in a package should have a package comment (staticcheck)
dynamo/dynamo.go:4:1: ST1000: at least one file in a package should have a package comment (staticcheck)
dynamo/options.go:4:1: ST1000: at least one file in a package should have a package comment (staticcheck)
```

## Linter Output After

```
0 issues.
```

## Testing

Verified with `golangci-lint run` - all issues resolved.