### PR TITLE
Add codecov configuration file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+coverage:
+  range: 80..100
+  round: down
+  precision: 2
+  status:
+    project: off
+    patch:
+      default:
+        target: 90%
+        threshold: 0.5%
+
+ignore:
+  - "*_test.go"
+  - "vendor"


### PR DESCRIPTION
## Summary

Add `.codecov.yml` configuration file to meet ideal state compliance requirements.

## Changes

- Create `.codecov.yml` in repository root
- Set coverage range: 80-100%
- Set patch target: 90% (with 0.5% threshold)
- Ignore `*_test.go` and `vendor/` directories

## Configuration Details

```yaml
coverage:
  range: 80..100
  round: down
  precision: 2
  status:
    project: off
    patch:
      default:
        target: 90%
        threshold: 0.5%

ignore:
  - "*_test.go"
  - "vendor"
```

This configuration matches the standard used in other xmidt-org Go repositories like [wrpssp](https://github.com/xmidt-org/wrpssp/blob/main/.codecov.yml).

Fixes #228